### PR TITLE
use addEventListener to allow `{ handleEvent }`

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -73,7 +73,7 @@ function belCreateElement (tag, props, children) {
       }
       // If a property prefers being set directly vs setAttribute
       if (key.slice(0, 2) === 'on') {
-        el[p] = val
+        el.addEventListener(key.slice(2), val)
       } else {
         if (ns) {
           if (p === 'xlink:href') {

--- a/browser.js
+++ b/browser.js
@@ -73,7 +73,8 @@ function belCreateElement (tag, props, children) {
       }
       // If a property prefers being set directly vs setAttribute
       if (key.slice(0, 2) === 'on') {
-        el.addEventListener(key.slice(2), val)
+        if (typeof val !== 'function') el.addEventListener(key.slice(2), val)
+        el[p] = val
       } else {
         if (ns) {
           if (p === 'xlink:href') {


### PR DESCRIPTION
to "fix" https://github.com/shama/bel/issues/103

I can see the unconvenience, that this PR removes the ability to remove the listener later.

If this is unwanted, maybe `val` can be checked and addEventListener would only be used if `val` is an object and not a function. Maybe in case of object, it could be assigned to `el.on[event.type]` too, so later it's possible to call `el.removeEventListener('click', el.onclick)` which a user would need to do before overwriting `el.onclick` with a custom handler.

