### PR TITLE
Add umd build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,19 @@
   "description": "HTML template strings for the Browser with support for Server Side Rendering in Node.",
   "repository": "choojs/nanohtml",
   "version": "1.1.0",
+  "main": "index.js",
+  "files": [
+    "index.js",
+    "raw.js",
+    "lib",
+    "types",
+    "dist"
+  ],
   "types": "./types/index.d.ts",
   "scripts": {
     "bench": "node bench/server.js && browserify bench/client.js | tape-run",
+    "build": "mkdir -p dist/ && browserify index -s html -p bundle-collapser/plugin > dist/bundle.js && browserify index -p tinyify > dist/bundle.min.js && cat dist/bundle.min.js | gzip --best --stdout | wc -c | pretty-bytes",
+    "prepublishOnly": "npm run build",
     "test": "standard && node tests && npm run test:browser && npm run test:transform-browser && npm run test:babel-browser",
     "test:browser": "browserify tests/browser | tape-run",
     "test:transform-browser": "node tests/transform/build | tape-run",
@@ -31,11 +41,13 @@
     "babelify": "^8.0.0",
     "browserify": "^16.1.1",
     "bubleify": "^1.1.0",
+    "bundle-collapser": "^1.3.0",
     "choo": "^6.9.0",
     "pify": "^3.0.0",
     "standard": "^10.0.3",
     "tape": "^4.8.0",
-    "tape-run": "^3.0.4"
+    "tape-run": "^3.0.4",
+    "tinyify": "^2.4.0"
   },
   "keywords": [
     "choo",


### PR DESCRIPTION
This add a build step with umd support. Added to [choojs/choo#617](https://github.com/choojs/choo/pull/617) this would allow devs to use choo completly as a standalone library.