### PR TITLE
adding xlink setAttributeNS to babel transform

### DIFF
--- a/lib/babel.js
+++ b/lib/babel.js
@@ -248,13 +248,12 @@ module.exports = (babel) => {
 
         // use proper xml namespace for svg use links
         if (attrName === 'xlink:href') {
-          const value = convertPlaceholders(props[propName]).filter(isNotEmptyString)
+          const value = convertPlaceholders(props[propName])
+            .map(ensureString)
+            .reduce(concatAttribute)
 
-          result.push(setDomAttributeNS(id, attrName,
-            value.length === 1
-              ? value[0]
-              : value.map(ensureString).reduce(concatAttribute),
-            XLINKNS))
+          state.xlinkNamespaceId.used = true
+          result.push(setDomAttributeNS(id, attrName, value, state.xlinkNamespaceId))
 
           return
         }
@@ -315,6 +314,7 @@ module.exports = (babel) => {
           this.appendChildId = path.scope.generateUidIdentifier('appendChild')
           this.setAttributeId = path.scope.generateUidIdentifier('setAttribute')
           this.svgNamespaceId = path.scope.generateUidIdentifier('svgNamespace')
+          this.xlinkNamespaceId = path.scope.generateUidIdentifier('xlinkNamespace')
         },
         exit (path, state) {
           const appendChildModule = this.opts.appendChildModule || 'nanohtml/lib/append-child'
@@ -331,6 +331,12 @@ module.exports = (babel) => {
             path.scope.push({
               id: this.svgNamespaceId,
               init: t.stringLiteral(SVGNS)
+            })
+          }
+          if (this.xlinkNamespaceId.used) {
+            path.scope.push({
+              id: this.xlinkNamespaceId,
+              init: t.stringLiteral(XLINKNS)
             })
           }
 

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -95,7 +95,7 @@ module.exports = (babel) => {
 
   const setDomAttributeNS = (id, attr, value, ns = null) =>
     t.callExpression(
-      t.memberExpression(id, t.identifier('setAttribute')),
+      t.memberExpression(id, t.identifier('setAttributeNS')),
       [ns, t.stringLiteral(attr), value])
 
   /**

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -93,7 +93,7 @@ module.exports = (babel) => {
       t.memberExpression(id, t.identifier('setAttribute')),
       [t.stringLiteral(attr), value])
 
-  const setDomAttributeNS = (id, attr, value, ns = null) =>
+  const setDomAttributeNS = (id, attr, value, ns = t.nullLiteral()) =>
     t.callExpression(
       t.memberExpression(id, t.identifier('setAttributeNS')),
       [ns, t.stringLiteral(attr), value])

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -6,6 +6,7 @@ const SVG_TAGS = require('./svg-tags')
 const BOOL_PROPS = require('./bool-props')
 
 const SVGNS = 'http://www.w3.org/2000/svg'
+const XLINKNS = 'http://www.w3.org/1999/xlink'
 
 /**
  * Try to return a nice variable name for an element based on its HTML id,
@@ -91,6 +92,11 @@ module.exports = (babel) => {
     t.callExpression(
       t.memberExpression(id, t.identifier('setAttribute')),
       [t.stringLiteral(attr), value])
+
+  const setDomAttributeNS = (id, attr, value, ns = null) =>
+    t.callExpression(
+      t.memberExpression(id, t.identifier('setAttribute')),
+      [ns, t.stringLiteral(attr), value])
 
   /**
    * Returns a node that sets a boolean DOM attribute.
@@ -237,6 +243,19 @@ module.exports = (babel) => {
           result.push(setBooleanAttribute(id, attrName,
             convertPlaceholders(props[propName])
               .filter(isNotEmptyString)[0]))
+          return
+        }
+
+        // use proper xml namespace for svg use links
+        if (attrName === 'xlink:href') {
+          const value = convertPlaceholders(props[propName]).filter(isNotEmptyString)
+
+          result.push(setDomAttributeNS(id, attrName,
+            value.length === 1
+              ? value[0]
+              : value.map(ensureString).reduce(concatAttribute),
+            XLINKNS))
+
           return
         }
 

--- a/tests/babel/fixtures/svg.expected.js
+++ b/tests/babel/fixtures/svg.expected.js
@@ -1,10 +1,12 @@
 var _path,
     _svg,
+    _use,
     _svg2,
     _div,
     _appendChild = require('nanohtml/lib/append-child'),
-    _svgNamespace = 'http://www.w3.org/2000/svg';
+    _svgNamespace = 'http://www.w3.org/2000/svg',
+    _xlinkNamespace = 'http://www.w3.org/1999/xlink';
 
 const svg = (_svg = document.createElementNS(_svgNamespace, 'svg'), _svg.setAttribute('viewBox', '0 14 32 18'), _appendChild(_svg, ['\n    ', (_path = document.createElementNS(_svgNamespace, 'path'), _path.setAttribute('d', 'M2 14 V18 H6 V14z'), _path), '\n  ']), _svg);
 
-const htmlAndSvg = (_div = document.createElement('div'), _appendChild(_div, ['\n    ', (_svg2 = document.createElementNS(_svgNamespace, 'svg'), _appendChild(_svg2, ['\n  ']), _svg2), '\n']), _div);
+const htmlAndSvg = (_div = document.createElement('div'), _appendChild(_div, ['\n    ', (_svg2 = document.createElementNS(_svgNamespace, 'svg'), _svg2.setAttribute('viewBox', '0 0 100 100'), _appendChild(_svg2, ['\n      ', (_use = document.createElementNS(_svgNamespace, 'use'), _use.setAttributeNS(_xlinkNamespace, 'xlink:href', '#foo'), _use), '\n    ']), _svg2), '\n  ']), _div);

--- a/tests/babel/fixtures/svg.js
+++ b/tests/babel/fixtures/svg.js
@@ -8,6 +8,8 @@ const svg = html`
 
 const htmlAndSvg = html`
   <div>
-    <svg />
+    <svg viewBox="0 0 100 100">
+      <use xlink:href="#foo" />
+    </svg>
   </div>
 `


### PR DESCRIPTION
fixes #122 

The babel transform script does not consider `xlink:href` attribute