### PR TITLE
Fix bool props

### DIFF
--- a/lib/bool-props.js
+++ b/lib/bool-props.js
@@ -1,4 +1,6 @@
 module.exports = [
-  'autofocus', 'checked', 'defaultchecked', 'disabled', 'formnovalidate',
-  'indeterminate', 'readonly', 'required', 'selected', 'willvalidate'
+  'async', 'autofocus', 'autoplay', 'checked', 'controls', 'default',
+  'defaultchecked', 'defer', 'disabled', 'formnovalidate', 'hidden',
+  'indeterminate', 'ismap', 'loop', 'multiple', 'muted', 'novalidate', 'open',
+  'playsinline', 'readonly', 'required', 'reversed', 'selected', 'willvalidate'
 ]

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,6 @@
 var BOOL_PROPS = require('./bool-props')
 
-var boolPropRx = new RegExp('(' + BOOL_PROPS.join('|') + ')=["\']?$', 'i')
+var boolPropRx = new RegExp('([^-a-z](' + BOOL_PROPS.join('|') + '))=["\']?$', 'i')
 
 module.exports = nanothtmlServer
 
@@ -22,7 +22,7 @@ function nanothtmlServer (src, filename, options, done) {
       if ((boolMatch = boolPropRx.exec(piece))) {
         output += piece.slice(0, boolMatch.index)
         if (arguments[i + 1]) {
-          output += boolMatch[1] + '="' + boolMatch[1] + '"'
+          output += boolMatch[1] + '="' + boolMatch[2] + '"'
         }
         continue
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-register": "^6.26.0",
     "babelify": "^8.0.0",
     "browserify": "^16.1.1",
-    "bubleify": "^1.1.0",
+    "bubleify": "1.1.0",
     "bundle-collapser": "^1.3.0",
     "choo": "^6.9.0",
     "pify": "^3.0.0",

--- a/tests/server/index.js
+++ b/tests/server/index.js
@@ -69,8 +69,8 @@ test('event attribute', function (t) {
 test('boolean attribute', function (t) {
   t.plan(1)
 
-  var expected = '<input disabled="disabled" >'
-  var result = html`<input disabled=${true} autofocus=${false}>`.toString()
+  var expected = '<input disabled="disabled" aria-selected="true">'
+  var result = html`<input disabled=${true} autofocus=${false} aria-selected="${true}">`.toString()
 
   t.equal(result, expected)
   t.end()


### PR DESCRIPTION
Add missing boolean properties and fix SSR boolean prop test.

The test for boolean properties only checks that the property name _includes_ a boolean property key, not that the actual property is a match, start to end. This means that attributes such as `aria-selected=${true}` and `data-selected=${true}` would be matched and either removed or have their value replaced with `selected`.