### PR TITLE
Remove excess props

### DIFF
--- a/lib/bool-props.js
+++ b/lib/bool-props.js
@@ -2,5 +2,5 @@ module.exports = [
   'async', 'autofocus', 'autoplay', 'checked', 'controls', 'default',
   'defaultchecked', 'defer', 'disabled', 'formnovalidate', 'hidden',
   'ismap', 'loop', 'multiple', 'muted', 'novalidate', 'open', 'playsinline',
-  'readonly', 'required', 'reversed', 'selected', 'willvalidate'
+  'readonly', 'required', 'reversed', 'selected'
 ]

--- a/lib/bool-props.js
+++ b/lib/bool-props.js
@@ -1,6 +1,6 @@
 module.exports = [
   'async', 'autofocus', 'autoplay', 'checked', 'controls', 'default',
   'defaultchecked', 'defer', 'disabled', 'formnovalidate', 'hidden',
-  'indeterminate', 'ismap', 'loop', 'multiple', 'muted', 'novalidate', 'open',
-  'playsinline', 'readonly', 'required', 'reversed', 'selected', 'willvalidate'
+  'ismap', 'loop', 'multiple', 'muted', 'novalidate', 'open', 'playsinline',
+  'readonly', 'required', 'reversed', 'selected', 'willvalidate'
 ]


### PR DESCRIPTION
It seems I was a tad too eager with #132. It turns out that `intermediate` is actually already listed under [lib/direct-props.js](../tree/master/lib/direct-props.js) and `willvalidate` isn't an attribute at all. My bad! 😳