### PR TITLE
Added default export in server code.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -3,6 +3,7 @@ var BOOL_PROPS = require('./bool-props')
 var boolPropRx = new RegExp('([^-a-z](' + BOOL_PROPS.join('|') + '))=["\']?$', 'i')
 
 module.exports = nanothtmlServer
+module.exports.default = module.exports
 
 function nanothtmlServer (src, filename, options, done) {
   if (typeof src === 'string' && !/\n/.test(src) && filename && filename._flags) {


### PR DESCRIPTION
This is necessary for nanohtml to work on the server via typescript.

The types declarations declares a default export:

```typescript
declare module "nanohtml" {
  export default function (strings: TemplateStringsArray, ...keys: any[]): HTMLElement;
  // ...
}
```

So its necessary for the code to match. The code in browser.js already does this.

Fixes #130