### PR TITLE
Trailing newline whitespace should result in a space in text nodes

### DIFF
--- a/lib/append-child.js
+++ b/lib/append-child.js
@@ -99,7 +99,7 @@ module.exports = function appendChild (el, childs) {
           VERBATIM_TAGS.indexOf(nodeName) === -1) {
           value = lastChild.nodeValue
             .replace(leadingNewlineRegex, '')
-            .replace(trailingNewlineRegex, '')
+            .replace(trailingNewlineRegex, ' ')
             .replace(multiSpaceRegex, ' ')
 
           // Remove empty text nodes, append otherwise

--- a/tests/browser/elements.js
+++ b/tests/browser/elements.js
@@ -133,6 +133,18 @@ test('space between text and non-text nodes', function (t) {
   t.end()
 })
 
+test('space between text followed by non-text nodes', function (t) {
+  t.plan(1)
+  var result = html`
+    <p>
+      whitespace
+      <strong>is strong</strong>
+    </p>
+  `
+  t.equal(result.outerHTML, '<p>whitespace <strong>is strong</strong></p>', 'should have correct output')
+  t.end()
+})
+
 test('space between non-text nodes', function (t) {
   t.plan(1)
   var result = html`


### PR DESCRIPTION
Hello choo crew :)

I've been having the following issue:

```html
<p>
  this
  <strong>text</strong>
<p>
```

should render like this:

```html
<p>this <strong>text</strong></p>
```

instead it renders like this:

```html
<p>this<strong>text</strong></p>
```

You can see this in action here: https://vigorous-austin-ab4675.netlify.com/
The first line ("expected") is what gets rendered when I write the HTML manually.
The second line ("actual") is rendered using nanohtml in [this file](https://vigorous-austin-ab4675.netlify.com/index.js).

I've written a failing test case, you can check out 4c56662 to verify that this happens.
The fix is to replace a trailing newline by a space rather than removing it completely.
I hope that this is always the right behavior, I can't think of any other edge case (ie. elements that should not have a space in between) at the moment.

Nice one, thanks folks ✌️