### PR TITLE
refactor: move supported views array to file

### DIFF
--- a/lib/babel.js
+++ b/lib/babel.js
@@ -5,6 +5,7 @@ const hyperx = require('hyperx')
 const SVG_TAGS = require('./svg-tags')
 const BOOL_PROPS = require('./bool-props')
 const DIRECT_PROPS = require('./direct-props')
+const SUPPORTED_VIEWS = require('./supported-views')
 
 const SVGNS = 'http://www.w3.org/2000/svg'
 const XLINKNS = 'http://www.w3.org/1999/xlink'
@@ -49,7 +50,6 @@ function removeBindingImport (binding) {
 
 module.exports = (babel) => {
   const t = babel.types
-  const nanohtmlModuleNames = ['nanohtml', 'bel', 'yo-yo', 'choo/html', 'hui/html']
 
   /**
    * Returns an object which specifies the custom elements by which a built-in is extended.
@@ -347,7 +347,7 @@ module.exports = (babel) => {
     }
 
     const importFrom = firstArg.value
-    return nanohtmlModuleNames.indexOf(importFrom) !== -1
+    return SUPPORTED_VIEWS.indexOf(importFrom) !== -1
   }
 
   return {
@@ -410,7 +410,7 @@ module.exports = (babel) => {
        */
       ImportDeclaration (path, state) {
         const importFrom = path.get('source').node.value
-        if (nanohtmlModuleNames.indexOf(importFrom) !== -1) {
+        if (SUPPORTED_VIEWS.indexOf(importFrom) !== -1) {
           const specifier = path.get('specifiers')[0]
           if (specifier.isImportDefaultSpecifier()) {
             this.nanohtmlBindings.add(path.scope.getBinding(specifier.node.local.name))

--- a/lib/browserify-transform.js
+++ b/lib/browserify-transform.js
@@ -6,8 +6,8 @@ var hyperx = require('hyperx')
 var acorn = require('acorn')
 var path = require('path')
 var SVG_TAGS = require('./svg-tags')
+var SUPPORTED_VIEWS = require('./supported-views')
 
-var SUPPORTED_VIEWS = ['nanohtml', 'bel', 'yo-yo', 'choo', 'choo/html', 'hui/html']
 var DELIM = '~!@|@|@!~'
 var VARNAME = 'nanohtml'
 var SVGNS = 'http://www.w3.org/2000/svg'

--- a/lib/supported-views.js
+++ b/lib/supported-views.js
@@ -1,0 +1,1 @@
+module.exports = ['nanohtml', 'bel', 'yo-yo', 'choo/html', 'hui/html']

--- a/lib/supported-views.js
+++ b/lib/supported-views.js
@@ -1,1 +1,8 @@
-module.exports = ['nanohtml', 'bel', 'yo-yo', 'choo/html', 'hui/html']
+module.exports = [
+  'nanohtml',
+  'bel',
+  'yo-yo',
+  'choo/html',
+  'choo', // Support choo 3.x-style require('choo').view``
+  'hui/html'
+]


### PR DESCRIPTION
Tried moving supported views array to file as suggested in https://github.com/choojs/nanohtml/pull/146#issuecomment-486587379

One thing worth noting: in `lib/browserify-transform.js`, `choo` is included in the list, whereas in `babel.js` it is not. My feeling is that it's not needed (`choo/html` is included in both), but I'd like confirmation of this from a maintainer before moving forward.

cc @goto-bus-stop 