### PR TITLE
Preserve trailing newline whitespace before text nodes

### DIFF
--- a/lib/append-child.js
+++ b/lib/append-child.js
@@ -108,13 +108,12 @@ module.exports = function appendChild (el, childs) {
           } else {
             lastChild.nodeValue = value
           }
-        // Trim the child nodes if the current node is not a node
-        // where all whitespace must be preserved
+        // Trim the child nodes but preserve the appropriate whitespace
         } else if (VERBATIM_TAGS.indexOf(nodeName) === -1) {
           value = lastChild.nodeValue
             .replace(leadingSpaceRegex, ' ')
             .replace(leadingNewlineRegex, '')
-            .replace(trailingNewlineRegex, '')
+            .replace(trailingNewlineRegex, ' ')
             .replace(multiSpaceRegex, ' ')
           lastChild.nodeValue = value
         }

--- a/tests/browser/elements.js
+++ b/tests/browser/elements.js
@@ -168,6 +168,19 @@ test('space between text followed by non-text nodes', function (t) {
   t.end()
 })
 
+test('space around text surrounded by non-text nodes', function (t) {
+  t.plan(1)
+  var result = html`
+    <p>
+      <strong>I agree</strong>
+      whitespace
+      <strong>is strong</strong>
+    </p>
+  `
+  t.equal(result.outerHTML, '<p><strong>I agree</strong> whitespace <strong>is strong</strong></p>', 'should have correct output')
+  t.end()
+})
+
 test('space between non-text nodes', function (t) {
   t.plan(1)
   var result = html`


### PR DESCRIPTION
#142 was a great start but it didn't quite fix the whitespace issue for me around text nodes. See the test in this PR for an example of a problem I'm running into.