### PR TITLE
Fix #141

### DIFF
--- a/lib/append-child.js
+++ b/lib/append-child.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var trailingNewlineRegex = /\n[\s]+$/
 var leadingNewlineRegex = /^\n[\s]+/
 var trailingSpaceRegex = /[\s]+$/

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -32,7 +32,7 @@ const placeholderRe = /\0(\d+)\0/g
 /**
  * Get a placeholder string for a numeric ID.
  */
-const getPlaceholder = (i) => `\0${i}\0`
+const getPlaceholder = (i) => `\u0000${i}\u0000`
 
 /**
  * Remove a binding and its import or require() call from the file.

--- a/lib/bool-props.js
+++ b/lib/bool-props.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = [
   'async', 'autofocus', 'autoplay', 'checked', 'controls', 'default',
   'defaultchecked', 'defer', 'disabled', 'formnovalidate', 'hidden',

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var hyperx = require('hyperx')
 var appendChild = require('./append-child')
 var SVG_TAGS = require('./svg-tags')

--- a/lib/browserify-transform.js
+++ b/lib/browserify-transform.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var isMemberExpression = require('estree-is-member-expression')
 var convertSourceMap = require('convert-source-map')
 var transformAst = require('transform-ast')

--- a/lib/direct-props.js
+++ b/lib/direct-props.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = [
   'indeterminate'
 ]

--- a/lib/raw-browser.js
+++ b/lib/raw-browser.js
@@ -1,3 +1,5 @@
+'use strict'
+
 function nanohtmlRawBrowser (tag) {
   var el = document.createElement('div')
   el.innerHTML = tag

--- a/lib/raw-server.js
+++ b/lib/raw-server.js
@@ -1,3 +1,5 @@
+'use strict'
+
 function nanohtmlRawServer (tag) {
   var wrapper = new String(tag) // eslint-disable-line no-new-wrappers
   wrapper.__encoded = true

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var BOOL_PROPS = require('./bool-props')
 
 var boolPropRx = new RegExp('([^-a-z](' + BOOL_PROPS.join('|') + '))=["\']?$', 'i')

--- a/lib/set-attribute.js
+++ b/lib/set-attribute.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var DIRECT_PROPS = require('./direct-props')
 
 module.exports = function nanohtmlSetAttribute (el, attr, value) {

--- a/lib/supported-views.js
+++ b/lib/supported-views.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = [
   'nanohtml',
   'bel',

--- a/lib/svg-tags.js
+++ b/lib/svg-tags.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = [
   'svg', 'altGlyph', 'altGlyphDef', 'altGlyphItem', 'animate', 'animateColor',
   'animateMotion', 'animateTransform', 'circle', 'clipPath', 'color-profile',


### PR DESCRIPTION
Consistently 'use strict' everywhere, babel.js already did it.
Changed the octal escapes to \unicode escape.

Tested by doing `terser lib/*.js`