### PR TITLE
Allow arrays in fragments

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -94,8 +94,13 @@ function nanoHtmlCreateElement (tag, props, children) {
 function createFragment (nodes) {
   var fragment = document.createDocumentFragment()
   for (var i = 0; i < nodes.length; i++) {
-    if (typeof nodes[i] === 'string') nodes[i] = document.createTextNode(nodes[i])
-    fragment.appendChild(nodes[i])
+    if (nodes[i] == null) continue
+    if (Array.isArray(nodes[i])) {
+      fragment.appendChild(createFragment(nodes[i]))
+    } else {
+      if (typeof nodes[i] === 'string') nodes[i] = document.createTextNode(nodes[i])
+      fragment.appendChild(nodes[i])
+    }
   }
   return fragment
 }

--- a/tests/browser/multiple.js
+++ b/tests/browser/multiple.js
@@ -25,3 +25,18 @@ test('nested fragments', function (t) {
   t.equals(fragments.childNodes.length, 7)
   t.end()
 })
+
+test('multiple elements mixed with array', function (t) {
+  var arr = [html`<li>Helsinki</li>`, null, html`<li>Stockholm</li>`]
+  var multiple = html`<li>Hamburg</li>${arr}<li>Berlin</li>`
+
+  var list = document.createElement('ul')
+  list.appendChild(multiple)
+  t.equal(list.children.length, 4, '4 children')
+  t.equal(list.children[0].tagName, 'LI', 'list tag name')
+  t.equal(list.children[0].textContent, 'Hamburg')
+  t.equal(list.children[1].textContent, 'Helsinki')
+  t.equal(list.children[2].textContent, 'Stockholm')
+  t.equal(list.children[3].textContent, 'Berlin')
+  t.end()
+})


### PR DESCRIPTION
This allows for arrays as direct children of document fragments, just like it works with a root node.


## This has always worked:
```javascript
var train = ['🚂', '🚃', '🚃', '🚃']
html`
  <body>
    <h1>Hello planet!</h1>
    ${train.map((char) => html`<span>${char}</span>`)}
  </body>
`
```

## But this hasn't, and now it does:
```javascript
var train = ['🚂', '🚃', '🚃', '🚃']
html`
  <h1>Hello planet!</h1>
  ${train.map((char) => html`<span>${char}</span>`)}
`
```