### PR TITLE
Add back node test in test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bench": "node bench/server.js && browserify bench/client.js | tape-run",
     "build": "mkdir -p dist/ && browserify index -s html -p bundle-collapser/plugin > dist/bundle.js && browserify index -p tinyify > dist/bundle.min.js && cat dist/bundle.min.js | gzip --best --stdout | wc -c | pretty-bytes",
     "prepublishOnly": "npm run build",
-    "test": "npm run test:standard && npm run test:browser && npm run test:browser && npm run test:transform-browser && npm run test:babel-browser",
+    "test": "npm run test:standard && npm run test:node && npm run test:browser && npm run test:browser && npm run test:transform-browser && npm run test:babel-browser",
     "test:standard": "standard",
     "test:node": "node tests",
     "test:browser": "browserify tests/browser | tape-run",


### PR DESCRIPTION
I noticed that #154 dropped the node tests from the `test` script. This just adds that back in there so all tests are run with `npm test`.