### PR TITLE
Check for (probable) query before auto-quote

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -3,6 +3,7 @@
 var BOOL_PROPS = require('./bool-props')
 
 var boolPropRx = new RegExp('([^-a-z](' + BOOL_PROPS.join('|') + '))=["\']?$', 'i')
+var query = /(?:="|&)[^"]*=$/
 
 module.exports = nanothtmlServer
 module.exports.default = module.exports
@@ -31,7 +32,7 @@ function nanothtmlServer (src, filename, options, done) {
       }
 
       var value = handleValue(arguments[i + 1])
-      if (piece[piece.length - 1] === '=') {
+      if (piece[piece.length - 1] === '=' && !query.test(piece)) {
         output += piece + '"' + value + '"'
       } else {
         output += piece + value

--- a/tests/server/index.js
+++ b/tests/server/index.js
@@ -53,6 +53,28 @@ test('unescape html inside html', function (t) {
   t.end()
 })
 
+test('quote attributes', function (t) {
+  t.plan(1)
+
+  var title = 'greeting'
+  var expected = '<span title="greeting">Hello there</span>'
+  var result = html`<span title=${title}>Hello there</span>`.toString()
+
+  t.equal(result, expected)
+  t.end()
+})
+
+test('respect query parameters', function (t) {
+  t.plan(1)
+
+  var param = 'planet'
+  var expected = '<a href="/greeting?query=planet">Hello planet</a>'
+  var result = html`<a href="/greeting?query=${param}">Hello planet</a>`.toString()
+
+  t.equal(result, expected)
+  t.end()
+})
+
 test('event attribute', function (t) {
   t.plan(1)
 


### PR DESCRIPTION
For convenience nanohtml automatically adds quotes around unquoted attributes, allowing one to write:

```javascript
html`<span class=${'foo'}>Hello there</span>` // <span class="foo">Hello there</span>
```

However, the check for unquoted attributes would also quote query parameters as the syntax looks similar to attributes:

```javascript
html`<a href="/foo?bar=${'baz'}">click me</a>` // <a href="/foo?bar="baz"">click me</a>
```

This change checks wether the part that appears to be an attribute actually is a query. I have tested the regex against these strings and I think that it covers all following scenarios:

```bash 
# it matches these
&foo=
href="foo?bar=
```

```bash
# it does not match these
" class=
class=
<div class=
```