### PR TITLE
Add nanohtml/raw to index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,3 +2,7 @@ declare module "nanohtml" {
   export default function (strings: TemplateStringsArray, ...keys: any[]): HTMLElement;
   export function createElement (tag: string, attributes: any, children: Array<any>): HTMLElement;
 }
+
+declare module "nanohtml/raw" {
+  export default function raw(tag: string): ChildNode[] | string;
+}


### PR DESCRIPTION
I'm not the most familiar with how to generate `index.d.ts` files so I just added this by hand while guessing at the types based on a read through the code. It seems to work for my repo, but I don't know if there's a better way to do it (for instance, to separate out the server and browser use cases).