### PR TITLE
Handle all items of array value

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -51,8 +51,8 @@ function nanothtmlServer (src, filename, options, done) {
 }
 
 function handleValue (value) {
-  // Suppose that each item is a result of html``.
-  if (Array.isArray(value)) return value.join('')
+  // Handle each item in array as potential unescaped value
+  if (Array.isArray(value)) return value.map(handleValue).join('')
 
   // Ignore event handlers. `onclick=${(e) => doSomething(e)}`
   // will become.           `onclick=""`

--- a/tests/server/index.js
+++ b/tests/server/index.js
@@ -33,6 +33,26 @@ test('style attribute', function (t) {
   t.end()
 })
 
+test('escape text inside html', function (t) {
+  t.plan(1)
+
+  var expected = '<span>Hello &lt;3</span>'
+  var result = html`<span>${'Hello <3'}</span>`.toString()
+
+  t.equal(result, expected)
+  t.end()
+})
+
+test('escape array of text inside html', function (t) {
+  t.plan(1)
+
+  var expected = '<span>Hello &lt;3</span>'
+  var result = html`<span>${['Hello', ' ', '<3']}</span>`.toString()
+
+  t.equal(result, expected)
+  t.end()
+})
+
 test('unescape html', function (t) {
   t.plan(1)
 


### PR DESCRIPTION
This change will handle each item of an interpolated array as a potentially unescaped value. The previous implementation (naively) assumed that all items of an array are the result of `html`. In my experience there are several situations where that may not be the case, especially when working with external sources of data, e.g. APIs or a CMS.

An alternative would be to rely on the user running each string in an array through `html` but it seems a bit excessive.

I can't see this breaking anything or having any noticeable negative effect on performance as already formatted results of `html` are identified and returned quickly. So I guess it would count as a minor release.